### PR TITLE
Object clone circular

### DIFF
--- a/lib/util/clone-obj.js
+++ b/lib/util/clone-obj.js
@@ -11,7 +11,7 @@ var clone = module.exports = function(obj, seen) {
     return obj;
   }
 
-  seen.push(obj);
+  seen = seen.concat([obj]);
 
   var target = Array.isArray(obj) ? [] : {};
 

--- a/spec/util-spec.coffee
+++ b/spec/util-spec.coffee
@@ -1,4 +1,5 @@
 uri = require('../lib/util/uri-helpers')
+clone = require('../lib/util/clone-obj')
 
 xdescribe 'resolveURL()', ->
   it 'should replace the last segment', ->
@@ -15,3 +16,28 @@ xdescribe 'resolveURL()', ->
 
   it 'should resolve fully-qualified URIs', ->
     expect(uri.resolveURL('//site.com/a/b/c', 'x/y')).toBe '//site.com/a/b/x/y'
+
+describe 'clone()', ->
+  it 'should clone', ->
+    object =
+      name: 'hello'
+    result = clone(object)
+    expect(object).toEqual result
+    expect(object).not.toBe result
+
+  it 'should throw for circular objects', ->
+    circular =
+      prop:
+        name: 'foo'
+    circular.prop.otherProp = circular.prop
+    expect(-> clone(circular)).toThrow('unable dereference circular structures');
+
+  it 'should permit shared subobjects', ->
+    subobject =
+      name: 'hello'
+    object =
+      one: subobject
+      two: subobject
+    result = clone(object)
+    expect(object).toEqual result
+    expect(object).not.toBe result


### PR DESCRIPTION
This fixes an issue (`Error: unable dereference circular structures`) I ran into for objects with shared subobjects. When you have an object like below:

``` coffeescript
subobject =
  name: 'hello'
object =
  one: subobject
  two: subobject
```

keeping a list of seen objects across the entire object graph can result in false warnings for circular structures. By cloning `seen` before recursing, we can ensure that we only check our parents in the object graph, which is sufficient to prevent circular structures.
